### PR TITLE
moved size constraints into separate java class.

### DIFF
--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/constraints/SizeConstraint.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/constraints/SizeConstraint.java
@@ -1,0 +1,37 @@
+package ch.baloise.corellia.api.constraints;
+
+public class SizeConstraint {
+  public final static int FIRST_NAME_MIN_SIZE = 2;
+  public final static int FIRST_NAME_MAX_SIZE  = 35;
+  public final static int LAST_NAME_MIN_SIZE = 2;
+  public final static int LAST_NAME_MAX_SIZE = 35;
+
+  public final static int EMAIL_MIN_SIZE = 2;
+  public final static int EMAIL_MAX_SIZE = 70;
+  public final static int PHONE_NUMBER_MIN_SIZE = 5;
+  public final static int PHONE_NUMBER_MAX_SIZE = 20;
+
+  public final static int LANGUAGE_SIZE = 2;
+
+  public final static int COMPANY_NAME_MIN_SIZE = 3;
+  public final static int COMPANY_NAME_MAX_SIZE = 70;
+  public final static int UID_NUMBER_MAX_SIZE = 15;
+
+  public final static int AGENT_NUMBER_MAX_SIZE = 8;
+
+  public final static int STREET_MAX_SIZE = 35;
+  public final static int HOUSE_NUMBER_MAX_SIZE = 10;
+  public final static int ZIP_CODE_SIZE = 4;
+  public final static int CITY_MAX_SIZE = 10;
+
+  public final static int LIST_MAX_SIZE = 99;
+  public final static int MONTH_YEAR_SIZE = 4;
+  public final static int FILE_NAME_MAX_SIZE = 256;
+  public final static int MESSAGE_MIN_SIZE = 1;
+  public final static int MESSAGE_MAX_SIZE = 1024;
+
+  public final static int CONTRACT_ID_MAX_SIZE = 20;
+
+  public final static int CONTRACT_REFERENCE_MIN_SIZE = 1;
+  public final static int CONTRACT_REFERENCE_MAX_SIZE = 30;
+}

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Address.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Address.java
@@ -4,24 +4,26 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.*;
+
 public class Address implements Serializable {
 
   private static final long serialVersionUID = 10;
 
   @NotNull
-  @Size(max = 35)
+  @Size(max = STREET_MAX_SIZE)
   private String street;
 
   @NotNull
-  @Size(max = 10)
+  @Size(max = HOUSE_NUMBER_MAX_SIZE)
   private String houseNumber;
 
   @NotNull
-  @Size(max = 4)
+  @Size(min = ZIP_CODE_SIZE, max = ZIP_CODE_SIZE)
   private String zipCode;
 
   @NotNull
-  @Size(max = 30)
+  @Size(max = CITY_MAX_SIZE)
   private String city;
 
   public Address() {

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Agent.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Agent.java
@@ -6,17 +6,19 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.*;
+
 public class Agent implements Serializable {
 
   private static final long serialVersionUID = 10;
 
   @NotNull
-  @Size(max = 8)
+  @Size(max = AGENT_NUMBER_MAX_SIZE)
   @JsonPropertyDescription("Identification of an Agent")
   private String agentNumber;
 
   @NotNull
-  @Size(max = 70)
+  @Size(min = EMAIL_MIN_SIZE, max = EMAIL_MAX_SIZE)
   @JsonPropertyDescription("A valid email adress")
   private String email;
 

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Company.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Company.java
@@ -7,15 +7,17 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.*;
+
 public class Company implements Serializable {
 
   private static final long serialVersionUID = 10;
 
   @NotNull
-  @Size(min = 3, max = 70)
+  @Size(min = COMPANY_NAME_MIN_SIZE, max = COMPANY_NAME_MAX_SIZE)
   private String name;
 
-  @Size(max = 15)
+  @Size(max = UID_NUMBER_MAX_SIZE)
   @JsonPropertyDescription("identifies a company uniquely, example CHE-105.805.649")
   private String uidNumber;
 
@@ -24,12 +26,12 @@ public class Company implements Serializable {
   private Person.Salutation contactSalutation;
 
   @NotNull
-  @Size(min = 2, max = 35)
+  @Size(min = LAST_NAME_MIN_SIZE, max = LAST_NAME_MAX_SIZE)
   @JsonPropertyDescription("a contact is a person representing the company")
   private String contactLastName;
 
   @NotNull
-  @Size(min = 2, max = 35)
+  @Size(min = FIRST_NAME_MIN_SIZE, max = FIRST_NAME_MAX_SIZE)
   @JsonPropertyDescription("a contact is a person representing the company")
   private String contactFirstName;
 

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Contract.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Contract.java
@@ -9,6 +9,8 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.*;
+
 public class Contract implements Serializable {
 
   private static final long serialVersionUID = 10;
@@ -26,7 +28,7 @@ public class Contract implements Serializable {
   private LocalDate endDate;
 
   @NotNull
-  @Size(max = 20)
+  @Size(max = CONTRACT_ID_MAX_SIZE)
   @JsonPropertyDescription("id given by SaaS provider")
   private String contractId;
 
@@ -36,7 +38,7 @@ public class Contract implements Serializable {
 
   @NotNull
   @Valid
-  @Size(min = 1, max = 99)
+  @Size(min = 1, max = LIST_MAX_SIZE)
   @JsonPropertyDescription("all roles in the contract, e.g. insuranceHolder")
   private List<Role> roles;
 
@@ -54,12 +56,12 @@ public class Contract implements Serializable {
   private Payment payment;
 
   @NotNull
-  @Size(min = 1, max = 99)
+  @Size(min = 1, max = LIST_MAX_SIZE)
   @JsonPropertyDescription("a contract is only complete with its corresponding documents. This is the contract issued by the SaaS provider and maybe some further documents like e.g. customer provided documents like e.g. receipts")
   private List<FileHandle> fileHandles;
 
   @NotNull
-  @Size(min = 4, max = 4)
+  @Size(min = MONTH_YEAR_SIZE, max = MONTH_YEAR_SIZE)
   @JsonPropertyDescription("when was the condition issued? Format MMYY")
   private String conditionMonthYear;
 

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/ContractReference.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/ContractReference.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import javax.validation.constraints.Size;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.CONTRACT_REFERENCE_MAX_SIZE;
+import static ch.baloise.corellia.api.constraints.SizeConstraint.CONTRACT_REFERENCE_MIN_SIZE;
+
 public class ContractReference {
 
-  @Size(min = 1, max = 30)
+  @Size(min = CONTRACT_REFERENCE_MIN_SIZE, max = CONTRACT_REFERENCE_MAX_SIZE)
   @JsonPropertyDescription("under this reference the contract is stored at Baloise")
   private String reference;
 

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Coverable.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Coverable.java
@@ -8,6 +8,8 @@ import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.List;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.LIST_MAX_SIZE;
+
 public class Coverable implements Serializable {
 
   private static final long serialVersionUID = 10;
@@ -18,7 +20,7 @@ public class Coverable implements Serializable {
 
   @NotNull
   @Valid
-  @Size(min = 1, max = 99)
+  @Size(min = 1, max = LIST_MAX_SIZE)
   private List<Coverage> coverages;
 
   public Coverable() {

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Document.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Document.java
@@ -6,6 +6,9 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.CONTRACT_ID_MAX_SIZE;
+import static ch.baloise.corellia.api.constraints.SizeConstraint.FILE_NAME_MAX_SIZE;
+
 public class Document implements Serializable {
 
   private static final long serialVersionUID = 10;
@@ -18,7 +21,7 @@ public class Document implements Serializable {
   private byte[] data;
 
   @NotNull
-  @Size(max = 30)
+  @Size(max = CONTRACT_ID_MAX_SIZE)
   @JsonPropertyDescription("the contract this document belongs to")
   private String contractId;
 
@@ -27,7 +30,7 @@ public class Document implements Serializable {
   private MediaType mediaType;
 
   @NotNull
-  @Size(max = 256)
+  @Size(max = FILE_NAME_MAX_SIZE)
   private String fileName;
 
   @NotNull

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/ErrorResponse.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/ErrorResponse.java
@@ -22,13 +22,16 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.MESSAGE_MAX_SIZE;
+import static ch.baloise.corellia.api.constraints.SizeConstraint.MESSAGE_MIN_SIZE;
+
 public class ErrorResponse {
 
   @NotNull
   private ErrorCause errorCause;
 
   @NotNull
-  @Size(min = 1, max = 1024)
+  @Size(min = MESSAGE_MIN_SIZE, max = MESSAGE_MAX_SIZE)
   @JsonPropertyDescription("information about the error")
   private String message;
 

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Person.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Person.java
@@ -9,6 +9,8 @@ import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.time.LocalDate;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.*;
+
 public class Person implements Serializable {
 
   private static final long serialVersionUID = 10;
@@ -19,11 +21,11 @@ public class Person implements Serializable {
   private Salutation salutation;
 
   @NotNull
-  @Size(min = 2, max = 35)
+  @Size(min = LAST_NAME_MIN_SIZE, max = LAST_NAME_MAX_SIZE)
   private String lastName;
 
   @NotNull
-  @Size(min = 2, max = 35)
+  @Size(min = FIRST_NAME_MIN_SIZE, max = FIRST_NAME_MAX_SIZE)
   private String firstName;
 
   private LocalDate dateOfBirth;
@@ -31,11 +33,11 @@ public class Person implements Serializable {
   @Valid
   private PhoneNumber phoneNumber;
 
-  @Size(min = 0, max = 70)
+  @Size(min = EMAIL_MIN_SIZE, max = EMAIL_MAX_SIZE)
   @JsonPropertyDescription("A valid email address")
   private String emailAddress;
 
-  @Size(min = 2, max = 2)
+  @Size(min = LANGUAGE_SIZE, max = LANGUAGE_SIZE)
   @JsonProperty
   @JsonPropertyDescription("The language for correspondence with the customer. According to ISO 639-1 language codes, only the values 'de', 'fr', 'it' or 'en' are accepted.")
   private String language;

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/PhoneNumber.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/PhoneNumber.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.PHONE_NUMBER_MAX_SIZE;
+import static ch.baloise.corellia.api.constraints.SizeConstraint.PHONE_NUMBER_MIN_SIZE;
+
 public class PhoneNumber {
 
   @JsonPropertyDescription("Country code, default is +41.")
   private String countryCode;
 
   @NotNull
-  @Size(min = 5, max = 20)
+  @Size(min = PHONE_NUMBER_MIN_SIZE, max = PHONE_NUMBER_MAX_SIZE)
   @JsonPropertyDescription("Phone number, without the leading zero.")
   private String phoneNumber;
 

--- a/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Product.java
+++ b/corllia-api-java/src/main/java/ch/baloise/corellia/api/entities/Product.java
@@ -8,6 +8,9 @@ import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.List;
 
+import static ch.baloise.corellia.api.constraints.SizeConstraint.LIST_MAX_SIZE;
+import static ch.baloise.corellia.api.constraints.SizeConstraint.MONTH_YEAR_SIZE;
+
 public class Product implements Serializable {
 
   private static final long serialVersionUID = 10;
@@ -17,13 +20,13 @@ public class Product implements Serializable {
   private Integer code;
 
   @NotNull
-  @Size(min = 4, max = 4)
+  @Size(min = MONTH_YEAR_SIZE, max = MONTH_YEAR_SIZE)
   @JsonPropertyDescription("The month/year in which the pricing for the contract was set. Format MMYY")
   private String pricingMonthYear;
 
   @NotNull
   @Valid
-  @Size(min = 0, max = 99)
+  @Size(min = 0, max = LIST_MAX_SIZE)
   private List<Coverable> coverables;
 
   public Product() {}


### PR DESCRIPTION
moved size contraints into separate java file, to
1.) enable reusage of the contraints in other repositories
2.) prevent inconsistencies (e.g. max size of contractId was 20 in one DTO and 30 in another one)