### PR TITLE
Switch to actual artifact scanning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,14 +47,14 @@ pipeline {
         stage("CI build") {
             steps {
                 mavenbuild uploadArtifactsWithBranchnameInVersion: true,
-                           mavenArgs: "-DcreateChecksum=true -Dmaven.javadoc.skip=true dependency:copy-dependencies"
+                           mavenArgs: "-DcreateChecksum=true -Dmaven.javadoc.skip=true"
             }
         }
 
         stage("Nexus Lifecycle") {
             steps {
                 nexusPolicyEvaluation iqApplication: 'com.baloise.open.corellia', 
-                    iqScanPatterns: [[scanPattern: 'target/dependency/*.jar']], 
+                    iqScanPatterns: [[scanPattern: 'target/*.jar']], 
                     iqStage: 'build'
             }
         }


### PR DESCRIPTION
Now we scan the actual artifact instead of all transitive (optional build time) dependencies. This avoids noise within our internal auditing tools