### PR TITLE
Fix build description version information

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,10 +37,6 @@ pipeline {
             steps {
                 deleteDir()
                 checkout scm
-                script {
-                    pomInfo = readMavenPom file: 'pom.xml'
-                    currentBuild.description = "${pomInfo.version}"
-                }
             }
         }
 
@@ -48,6 +44,10 @@ pipeline {
             steps {
                 mavenbuild uploadArtifactsWithBranchnameInVersion: true,
                            mavenArgs: "-DcreateChecksum=true -Dmaven.javadoc.skip=true"
+                script {
+                    pomInfo = readMavenPom file: 'pom.xml'
+                    currentBuild.description = "${pomInfo.version}"
+                }
             }
         }
 


### PR DESCRIPTION
Fixes build description version information for multi-branch pipeline builds. 

## Proposed Changes
 - set information after branch identifier has been applied to version instead of before

## Definition of Done (DoD) - criteria met

 - [x] code compiles and [build is green](https://travis-ci.org/baloise/corellia)
 - [x] SonarQube Rating A
 - [x] documentation is appropriate or has been updated accordingly
 - [x] [Codecov](https://codecov.io/gh/baloise/corellia) test execution coverage not lowered (aim: 80%)
 - [x] change is (to be) merged on master branch
 - [ ] change has been deployed in target environment for acceptance testing
