### PR TITLE
Revert "manually released to version 1.0.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>ch.baloise.corellia</groupId>
   <artifactId>api</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <ciManagement>


### PR DESCRIPTION
Reverts baloise/corellia#83
did'nt work as expected as our baloise ci build release to baloise snapshots repository which is only accepting -SNAPSHOT builds. To change this build script to ci build to production repository would be too hacky