### PR TITLE
Cleanup Travis --> GH Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: java
-jdk:
-  - openjdk8
-  
-script: "mvn cobertura:cobertura"
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![swagger-editor](https://img.shields.io/badge/open--API-in--editor-green.svg?style=flat&label=open-api-v2)](https://editor.swagger.io/?url=https://raw.githubusercontent.com/baloise/corellia/master/docs/swagger.json)
 [![DepShield Badge](https://depshield.sonatype.org/badges/baloise/corellia/depshield.svg)](https://depshield.github.io)
 [![CI Status](https://github.com/baloise/corellia/workflows/CI/badge.svg)](https://github.com/baloise/corellia/actions)
-[![Codecov](https://img.shields.io/codecov/c/github/baloise/corellia.svg)](https://codecov.io/gh/baloise/corellia)
 
 ## workspace
 [![Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/baloise/corellia)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 [![swagger-editor](https://img.shields.io/badge/open--API-in--editor-green.svg?style=flat&label=open-api-v3)](https://editor.swagger.io/?url=https://raw.githubusercontent.com/baloise/corellia/master/docs/openapi.json)
 [![swagger-editor](https://img.shields.io/badge/open--API-in--editor-green.svg?style=flat&label=open-api-v2)](https://editor.swagger.io/?url=https://raw.githubusercontent.com/baloise/corellia/master/docs/swagger.json)
 [![DepShield Badge](https://depshield.sonatype.org/badges/baloise/corellia/depshield.svg)](https://depshield.github.io)
-[![Build Status](https://travis-ci.org/baloise/corellia.svg?branch=master)](https://travis-ci.org/baloise/corellia)
+[![CI Status](https://github.com/baloise/corellia/workflows/CI/badge.svg)](https://github.com/baloise/corellia/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/baloise/corellia.svg)](https://codecov.io/gh/baloise/corellia)
-[![gitpod-IDE](https://img.shields.io/badge/open--IDE-as--gitpod-blue.svg?style=flat&label=openIDE)](https://gitpod.io#https://github.com/baloise/corellia)
+
+## workspace
+[![Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/baloise/corellia)
 
 ## about
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,9 @@ Fixes #
 
  -
  -
- -
 
 ## Definition of Done (DoD) - criteria met
 
  - [ ] code compiles and [build is green](https://travis-ci.org/baloise/corellia)
  - [ ] documentation is appropriate or has been updated accordingly
- - [ ] [Codecov](https://codecov.io/gh/baloise/corellia) test execution coverage not lowered (aim: 80%)
  - [ ] change is (to be) merged on master branch


### PR DESCRIPTION
Fixes duplicte CI usage

## Proposed Changes

 - switch to github actions
 - remove codecov.io integration (unused)

## Definition of Done (DoD) - criteria met

 - [x] code compiles and [build is green](https://travis-ci.org/baloise/corellia)
 - [x] documentation is appropriate or has been updated accordingly
 - [ ] [Codecov](https://codecov.io/gh/baloise/corellia) test execution coverage not lowered (aim: 80%)
 - [x] change is (to be) merged on master branch
